### PR TITLE
Adds lastUpdate filter

### DIFF
--- a/app/controllers/concerns/map_parameters.rb
+++ b/app/controllers/concerns/map_parameters.rb
@@ -35,7 +35,8 @@ module MapParameters
       :service,
       :zoom,
       :experimenter,
-      :experiment
+      :experiment,
+      :lastUpdate
     ]
     parameters = {}
 

--- a/lib/mongo_orion_client.rb
+++ b/lib/mongo_orion_client.rb
@@ -97,6 +97,15 @@ module MongoOrionClient
       qbuilder.merge!("_id.type" => /.*#{params[:type]}.*/)
     end
 
+    # Gets the lastUpdate param and if valif adds to the mongo query
+    # a filter for assets with a last update time greater or equal than it.
+    if params[:lastUpdate]
+      lastUpdate = Time.iso8601(params[:lastUpdate]) rescue nil
+      if lastUpdate
+        qbuilder.merge!("_id.TimeInstant" => { '$gte': Time.strptime(lastUpdate, '%Y-%m-%dT%H:%M:%S%z').to_time.utc })
+      end
+    end
+
     if params[:q]
       qbuilder.merge!({ "attrNames": params[:q] })
     end


### PR DESCRIPTION
This implements the `lastUpdate` filter parameter before documented but not implemented.

https://docs.organicity.eu/api/AssetDiscovery.html#operation--assets-get

This should allow queries like the following ones:

https://discovery.organicity.eu/v0/assets?lastUpdate=2017-07-04T12:00:47Z
https://discovery.organicity.eu/v0/assets?type=event&lastUpdate=2017-07-04T12:00:47Z
https://discovery.organicity.eu/v0/assets/sites/santander?type=event&lastUpdate=2017-07-04T12:00:47Z

This will filter assets with a `TimeInstant` greater than or equal than the `lastUpdate` parameter.  The parameter needs to be an ISO formatted timestamp.

@viktorsmari I don't have docker here. This code isn't tested. Could you check this works and deploy?